### PR TITLE
fix: Terraform Linting and Format

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -4,8 +4,8 @@ variable "region" {
 
 variable "sftp_users" {
   type = map(object({
-    user_name  = string,
-    public_key = string,
+    user_name          = string,
+    public_key         = string,
     bucket_permissions = optional(list(string))
   }))
   description = "The value which will be passed to the example module"

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,6 @@ locals {
 
   is_vpc = var.vpc_id != null
 
-  user_names = keys(var.sftp_users)
-
   user_names_map = {
     for user, val in var.sftp_users :
     user => merge(val, {
@@ -43,7 +41,7 @@ resource "aws_transfer_server" "default" {
       subnet_ids             = var.subnet_ids
       security_group_ids     = var.vpc_security_group_ids
       vpc_id                 = var.vpc_id
-      address_allocation_ids = var.eip_enabled ? aws_eip.sftp.*.id : var.address_allocation_ids
+      address_allocation_ids = var.eip_enabled ? aws_eip.sftp[*].id : var.address_allocation_ids
     }
   }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,12 +5,12 @@ output "id" {
 
 output "transfer_endpoint" {
   description = "The endpoint of the Transfer Server"
-  value       = module.this.enabled ? join("", aws_transfer_server.default.*.endpoint) : null
+  value       = module.this.enabled ? join("", aws_transfer_server.default[*].endpoint) : null
 }
 
 output "elastic_ips" {
   description = "Provisioned Elastic IPs"
-  value       = module.this.enabled && var.eip_enabled ? aws_eip.sftp.*.id : null
+  value       = module.this.enabled && var.eip_enabled ? aws_eip.sftp[*].id : null
 }
 
 output "s3_access_role_arns" {

--- a/variables.tf
+++ b/variables.tf
@@ -52,12 +52,6 @@ variable "subnet_ids" {
   default     = []
 }
 
-variable "vpc_endpoint_id" {
-  type        = string
-  description = "The ID of the VPC endpoint. This property can only be used when endpoint_type is set to VPC_ENDPOINT"
-  default     = null
-}
-
 variable "security_policy_name" {
   type        = string
   description = "Specifies the name of the security policy that is attached to the server. Possible values are TransferSecurityPolicy-2018-11, TransferSecurityPolicy-2020-06, and TransferSecurityPolicy-FIPS-2020-06. Default value is: TransferSecurityPolicy-2018-11."


### PR DESCRIPTION
## what
- Resolve some `tflint` warnings
- Format terraform with `terraform fmt`

## why
- CI checks require both of these conditions to pass

## references
- https://github.com/cloudposse/terraform-aws-transfer-sftp/pull/69