### PR TITLE
Satisfy TFLint and Bats requirements

### DIFF
--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -1,5 +1,6 @@
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS Region where resources will be created"
 }
 
 variable "sftp_users" {

--- a/examples/vpc/outputs.tf
+++ b/examples/vpc/outputs.tf
@@ -1,9 +1,9 @@
 output "id" {
-  description = "The ID of the AWS Transfer Server instance"
+  description = "ID of the created example"
   value       = module.sftp.id
 }
 
 output "transfer_endpoint" {
-  description = "The endpoint URL of the AWS Transfer Server for SFTP connections"
+  description = "Endpoint for your SFTP connection"
   value       = module.sftp.transfer_endpoint
 }

--- a/examples/vpc/outputs.tf
+++ b/examples/vpc/outputs.tf
@@ -1,9 +1,9 @@
 output "id" {
-  description = "ID of the created example"
+  description = "The ID of the AWS Transfer Server instance"
   value       = module.sftp.id
 }
 
 output "transfer_endpoint" {
-  description = "Endpoint for your SFTP connection"
+  description = "The endpoint URL of the AWS Transfer Server for SFTP connections"
   value       = module.sftp.transfer_endpoint
 }

--- a/examples/vpc/variables.tf
+++ b/examples/vpc/variables.tf
@@ -1,5 +1,6 @@
 variable "region" {
-  type = string
+  type        = string
+  description = "AWS Region where resources will be created"
 }
 
 variable "availability_zones" {

--- a/examples/vpc/variables.tf
+++ b/examples/vpc/variables.tf
@@ -15,8 +15,8 @@ variable "cidr_block" {
 
 variable "sftp_users" {
   type = map(object({
-    user_name  = string,
-    public_key = string,
+    user_name          = string,
+    public_key         = string,
     bucket_permissions = optional(list(string))
   }))
   description = "The value which will be passed to the example module"

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ locals {
   user_names_map = {
     for user, val in var.sftp_users :
     user => merge(val, {
-      s3_bucket_arn = lookup(val, "s3_bucket_name", null) != null ? "${local.s3_arn_prefix}${lookup(val, "s3_bucket_name")}" : one(data.aws_s3_bucket.landing[*].arn)
+      s3_bucket_arn = coalesce("${local.s3_arn_prefix}${val.s3_bucket_name}", one(data.aws_s3_bucket.landing[*].arn))
     })
   }
 }
@@ -56,24 +56,22 @@ resource "aws_transfer_user" "default" {
 
   user_name = each.value.user_name
 
-  home_directory_type = lookup(each.value, "home_directory_type", null) != null ? lookup(each.value, "home_directory_type") : (var.restricted_home ? "LOGICAL" : "PATH")
-  home_directory      = lookup(each.value, "home_directory", null) != null ? lookup(each.value, "home_directory") : (!var.restricted_home ? "/${lookup(each.value, "s3_bucket_name", var.s3_bucket_name)}" : null)
+  home_directory_type = coalesce(each.value.home_directory_type, var.restricted_home ? "LOGICAL" : "PATH")
+  home_directory      = coalesce(each.value.home_directory, !var.restricted_home ? "/${coalesce(each.value.s3_bucket_name, var.s3_bucket_name)}" : null)
 
   dynamic "home_directory_mappings" {
     for_each = var.restricted_home ? (
-      lookup(each.value, "home_directory_mappings", null) != null ? lookup(each.value, "home_directory_mappings") : [
+      coalesce(each.value.home_directory_mappings, [
         {
-          entry = "/"
-          # Specifically do not use $${Transfer:UserName} since subsequent terraform plan/applies will try to revert
-          # the value back to $${Tranfer:*} value
-          target = format("/%s/%s", lookup(each.value, "s3_bucket_name", var.s3_bucket_name), each.value.user_name)
+          entry  = "/"
+          target = format("/%s/%s", coalesce(each.value.s3_bucket_name, var.s3_bucket_name), each.value.user_name)
         }
-      ]
+      ])
     ) : toset([])
 
     content {
-      entry  = lookup(home_directory_mappings.value, "entry")
-      target = lookup(home_directory_mappings.value, "target")
+      entry  = home_directory_mappings.value.entry
+      target = home_directory_mappings.value.target
     }
   }
 
@@ -157,7 +155,7 @@ data "aws_iam_policy_document" "s3_access_for_sftp_users" {
     sid    = "HomeDirObjectAccess"
     effect = "Allow"
 
-    actions = lookup(each.value, "bucket_permissions", null) != null ? lookup(each.value, "bucket_permissions") : [
+    actions = coalesce(each.value.bucket_permissions, [
       "s3:PutObject",
       "s3:GetObject",
       "s3:DeleteObject",
@@ -165,7 +163,7 @@ data "aws_iam_policy_document" "s3_access_for_sftp_users" {
       "s3:GetObjectVersion",
       "s3:GetObjectACL",
       "s3:PutObjectACL"
-    ]
+    ])
 
     resources = [
       var.restricted_home ? "${each.value.s3_bucket_arn}/${each.value.user_name}/*" : "${each.value.s3_bucket_arn}/*"

--- a/main.tf
+++ b/main.tf
@@ -64,6 +64,8 @@ resource "aws_transfer_user" "default" {
       coalesce(each.value.home_directory_mappings, [
         {
           entry  = "/"
+          # Specifically do not use $${Transfer:UserName} since subsequent terraform plan/applies will try to revert
+          # the value back to $${Tranfer:*} value
           target = format("/%s/%s", coalesce(each.value.s3_bucket_name, var.s3_bucket_name), each.value.user_name)
         }
       ])

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_transfer_user" "default" {
     for_each = var.restricted_home ? (
       coalesce(each.value.home_directory_mappings, [
         {
-          entry  = "/"
+          entry = "/"
           # Specifically do not use $${Transfer:UserName} since subsequent terraform plan/applies will try to revert
           # the value back to $${Tranfer:*} value
           target = format("/%s/%s", coalesce(each.value.s3_bucket_name, var.s3_bucket_name), each.value.user_name)

--- a/variables.tf
+++ b/variables.tf
@@ -5,9 +5,20 @@ variable "domain" {
 }
 
 variable "sftp_users" {
-  type        = any
+  type = map(object({
+    user_name               = string
+    public_key             = string
+    s3_bucket_name         = optional(string)
+    bucket_permissions     = optional(list(string))
+    home_directory_type   = optional(string)
+    home_directory        = optional(string)
+    home_directory_mappings = optional(list(object({
+      entry  = string
+      target = string
+    })))
+  }))
   default     = {}
-  description = "List of SFTP usernames and public keys. The keys `user_name`, `public_key` are required. The keys `s3_bucket_name` and `bucket_permissions` are optional."
+  description = "Map of SFTP users and their configurations. Required: user_name, public_key. Optional: s3_bucket_name, bucket_permissions, home_directory_type, home_directory, home_directory_mappings"
 }
 
 variable "restricted_home" {

--- a/variables.tf
+++ b/variables.tf
@@ -6,12 +6,12 @@ variable "domain" {
 
 variable "sftp_users" {
   type = map(object({
-    user_name               = string
-    public_key             = string
-    s3_bucket_name         = optional(string)
-    bucket_permissions     = optional(list(string))
-    home_directory_type   = optional(string)
-    home_directory        = optional(string)
+    user_name           = string
+    public_key          = string
+    s3_bucket_name      = optional(string)
+    bucket_permissions  = optional(list(string))
+    home_directory_type = optional(string)
+    home_directory      = optional(string)
     home_directory_mappings = optional(list(object({
       entry  = string
       target = string


### PR DESCRIPTION
## what
- Replaced deprecated usage of `lookup`. We can use the `optional()` feature instead for a given variable
- Added all missing descriptions for variables and outputs

## why
- Satisfy TFLint and Bats requirements

## references
- https://github.com/cloudposse/terraform-aws-transfer-sftp/actions/runs/13036828275/job/36369273859?pr=69